### PR TITLE
include .gitignore file and Gruntfile for serving locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+*~
+cov-*
+coverage
+plato
+.idea
+.DS_Store

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,112 @@
+'use strict';
+
+module.exports = function(grunt) {
+  require('time-grunt')(grunt);
+  // Project Configuration
+  grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
+    watch: {
+      js: {
+        files: ['gruntfile.js', 'application.js', 'public/**/*.js'],
+        options: {
+          livereload: true
+        }
+      },
+      html: {
+        files: ['public/*.html'],
+        options: {
+          livereload: true
+        }
+      }
+    },
+    nodemon: {
+      dev: {
+        script: 'application.js',
+        options: {
+          args: [],
+          ignore: ['public/**'],
+          ext: 'js,html',
+          nodeArgs: [],
+          delayTime: 1,
+          env: {
+            PORT: 3000
+          },
+          cwd: __dirname
+        }
+      }
+    },
+    concurrent: {
+      serve: ['nodemon', 'watch', 'open:liveCloud'],
+      serveLocal: ['nodemon', 'watch', 'open:localCloud'],
+      debug: ['node-inspector', 'shell:debug', 'open:debug'],
+      options: {
+        logConcurrentOutput: true
+      }
+    },
+    env : {
+      options : {},
+      // environment variables - see https://github.com/jsoverson/grunt-env for more information
+      local: {
+        FH_USE_LOCAL_DB: true,
+        FH_SERVICE_MAP: function() {
+          /*
+           * Define the mappings for your services here - for local development.
+           * You must provide a mapping for each service you wish to access
+           * This can be a mapping to a locally running instance of the service (for local development)
+           * or a remote instance.
+           */
+          var serviceMap = {
+            'SERVICE_GUID_1': 'http://127.0.0.1:8010',
+            'SERVICE_GUID_2': 'https://host-and-path-to-service'
+          };
+          return JSON.stringify(serviceMap);
+        }
+      }
+    },
+    'node-inspector': {
+      dev: {}
+    },
+    shell: {
+      debug: {
+        options: {
+          stdout: true
+        },
+        command: 'env NODE_PATH=. node --debug-brk application.js'
+      }
+    },
+    open: {
+      debug: {
+        path: 'http://127.0.0.1:8001/debug?port=5858',
+        app: 'Google Chrome'
+      },
+      localCloud: {
+        path: 'http://127.0.0.1:8001?url=http://127.0.0.1:8080',
+        app: 'Google Chrome'
+      },
+      liveCloud: {
+        path: 'http://127.0.0.1:8001',
+        app: 'Google Chrome'
+      }
+    }
+  });
+
+  // Load NPM tasks
+  require('load-grunt-tasks')(grunt, {scope: 'devDependencies'});
+
+  // Making grunt default to force in order not to break the project.
+  grunt.option('force', true);
+
+grunt.registerTask('serve', function (target) {
+    if (target === 'local') {
+      grunt.task.run(['env:local','concurrent:serveLocal']);
+    } else {
+      // open with no url passed to fh-js-sdk
+      grunt.task.run(['env:local', 'concurrent:serve']);
+    }
+
+});
+
+  // grunt.registerTask('serve', ['env:local', 'concurrent:serve']);
+  grunt.registerTask('debug', ['env:local', 'concurrent:debug']);
+  grunt.registerTask('default', ['serve']);
+};

--- a/package.json
+++ b/package.json
@@ -5,5 +5,17 @@
     "express" : "3.3.4",
     "corser": "1.2.0"
   },
+  "devDependencies": {
+    "grunt-contrib-watch": "latest",
+    "grunt-nodemon": "0.2.0",
+    "grunt-concurrent": "latest",
+    "grunt-shell": "0.6.4",
+    "grunt-env": "~0.4.1",
+    "load-grunt-tasks": "~0.4.0",
+    "time-grunt": "~0.3.1",
+    "grunt-node-inspector": "~0.1.5",
+    "grunt-open": "~0.2.3",
+    "grunt": "^0.4.4"
+  },
   "main" : "application.js"
 }


### PR DESCRIPTION
Can now use
`grunt serve` and `grunt serve:local` in web apps