### PR TITLE
RHMAP-12936 Move devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "dependencies": {
     "corser": "1.2.0",
     "express": "3.3.4",
-    "fh-js-sdk": "^2.17.1"
-  },
-  "devDependencies": {
+    "fh-js-sdk": "^2.17.1",
     "browserify": "^13.1.0",
     "browserify-shim": "^3.8.12",
     "grunt": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "corser": "1.2.0",
     "express": "3.3.4",
-    "fh-js-sdk": "^2.17.1",
+    "fh-js-sdk": "^2.18.1",
     "browserify": "^13.1.0",
     "browserify-shim": "^3.8.12",
     "grunt": "^0.4.4",
@@ -13,12 +13,14 @@
     "grunt-concurrent": "latest",
     "grunt-contrib-watch": "latest",
     "grunt-env": "~0.4.1",
-    "grunt-node-inspector": "~0.4.2",
-    "grunt-nodemon": "0.2.0",
     "grunt-open": "~0.2.3",
     "grunt-shell": "0.6.4",
     "load-grunt-tasks": "~0.4.0",
     "time-grunt": "~0.3.1"
+  },
+  "devDependencies": {
+    "grunt-node-inspector": "~0.4.2",
+    "grunt-nodemon": "0.2.0"
   },
   "main": "application.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-advanced-webapp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "dependencies": {
     "corser": "1.2.0",
     "express": "3.3.4",

--- a/public/main.js
+++ b/public/main.js
@@ -11186,7 +11186,7 @@ module.exports = {
 },{"./data":33,"./fhparams":36,"./logger":42,"./queryMap":44}],31:[function(_dereq_,module,exports){
 module.exports = {
   "boxprefix": "/box/srv/1.1/",
-  "sdk_version": "2.17.4",
+  "sdk_version": "2.18.1",
   "config_js": "fhconfig.json",
   "INIT_EVENT": "fhinit",
   "INTERNAL_CONFIG_LOADED_EVENT": "internalfhconfigloaded",


### PR DESCRIPTION
Currently builds using an OpenShift MBaaS are failing, this moves the
dev dependencies to the dependencies section in `package.json`. Now
the `npm install --production` command succeeds.