### PR TITLE
RHMAP-13723 move grunt to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
   "name": "fh-advanced-webapp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "dependencies": {
     "corser": "1.2.0",
     "express": "3.3.4",
-    "fh-js-sdk": "^2.18.1",
+    "fh-js-sdk": "^2.18.1"
+  },
+  "devDependencies": {
+    "grunt-node-inspector": "~0.4.2",
+    "grunt-nodemon": "0.2.0",
     "browserify": "^13.1.0",
     "browserify-shim": "^3.8.12",
     "grunt": "^0.4.4",
@@ -17,10 +21,6 @@
     "grunt-shell": "0.6.4",
     "load-grunt-tasks": "~0.4.0",
     "time-grunt": "~0.3.1"
-  },
-  "devDependencies": {
-    "grunt-node-inspector": "~0.4.2",
-    "grunt-nodemon": "0.2.0"
   },
   "main": "application.js",
   "scripts": {


### PR DESCRIPTION
move all grunt related packages to `devDependencies` to fix a problem with fh-npm