### PR TITLE
RHMAP-15094 - add travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+group: edge
+sudo: required
+services:
+  - mongodb
+  - docker
+node_js:
+  - "0.10"
+  - "4.4.3"
+before_install:
+  - npm install fh-build -g
+  - fh-build template
+install: npm install

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -113,4 +113,5 @@ grunt.registerTask('serve', function (target) {
   grunt.registerTask('debug', ['env:local', 'concurrent:debug']);
   grunt.registerTask('default', ['serve']);
   grunt.loadNpmTasks('grunt-browserify');
+  grunt.loadNpmTasks('grunt-fh-build');
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -113,5 +113,4 @@ grunt.registerTask('serve', function (target) {
   grunt.registerTask('debug', ['env:local', 'concurrent:debug']);
   grunt.registerTask('default', ['serve']);
   grunt.loadNpmTasks('grunt-browserify');
-  grunt.loadNpmTasks('grunt-fh-build');
 };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "grunt-concurrent": "latest",
     "grunt-contrib-watch": "latest",
     "grunt-env": "~0.4.1",
+    "grunt-fh-build": "~0.5.0",
     "grunt-open": "~0.2.3",
     "grunt-shell": "0.6.4",
     "load-grunt-tasks": "~0.4.0",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "dependencies": {
     "corser": "1.2.0",
     "express": "3.3.4",
-    "fh-js-sdk": "^2.18.1"
-  },
-  "devDependencies": {
+    "fh-js-sdk": "^2.18.1",
     "grunt-node-inspector": "~0.4.2",
     "grunt-nodemon": "0.2.0",
     "browserify": "^13.1.0",
@@ -17,12 +15,12 @@
     "grunt-concurrent": "latest",
     "grunt-contrib-watch": "latest",
     "grunt-env": "~0.4.1",
-    "grunt-fh-build": "~0.5.0",
     "grunt-open": "~0.2.3",
     "grunt-shell": "0.6.4",
     "load-grunt-tasks": "~0.4.0",
     "time-grunt": "~0.3.1"
   },
+  "devDependencies": {},
   "main": "application.js",
   "scripts": {
     "start": "node application.js",


### PR DESCRIPTION
## Motivation
Missing travis build

## Result
Add travis file, move devDependencies to dependencies as fh-build runs npm install with the production flag set and add travis CI service to this repo

## Jira
https://issues.jboss.org/browse/RHMAP-15094